### PR TITLE
Apply Package Manager Structure

### DIFF
--- a/Editor/Behaviors/TransformerEditor.cs
+++ b/Editor/Behaviors/TransformerEditor.cs
@@ -41,11 +41,7 @@ namespace TouchScript.Editor.Behaviors
 
         public override void OnInspectorGUI()
         {
-#if UNITY_5_6_OR_NEWER
             serializedObject.UpdateIfRequiredOrScript();
-#else
-			serializedObject.UpdateIfDirtyOrScript();
-#endif
 
             GUILayout.Space(5);
 

--- a/Editor/EditorResources.cs
+++ b/Editor/EditorResources.cs
@@ -42,7 +42,7 @@ namespace TouchScript.Editor
         {
             path = string.Empty;
 
-            string searchStr = "/TouchScript/Editor/EditorResources/";
+            string searchStr = "/com.interactive-scape.touchscript/Editor/EditorResources/";
             string str = null;
 
             foreach (var assetPath in AssetDatabase.GetAllAssetPaths())

--- a/Editor/Gestures/GestureEditor.cs
+++ b/Editor/Gestures/GestureEditor.cs
@@ -101,11 +101,7 @@ namespace TouchScript.Editor.Gestures
 
         public override void OnInspectorGUI()
         {
-#if UNITY_5_6_OR_NEWER
             serializedObject.UpdateIfRequiredOrScript();
-#else
-			serializedObject.UpdateIfDirtyOrScript();
-#endif
 
             GUILayout.Space(5);
             bool display;

--- a/Editor/InputSources/StandardInputEditor.cs
+++ b/Editor/InputSources/StandardInputEditor.cs
@@ -57,11 +57,7 @@ namespace TouchScript.Editor.InputSources
 
         public override void OnInspectorGUI()
         {
-#if UNITY_5_6_OR_NEWER
             serializedObject.UpdateIfRequiredOrScript();
-#else
-			serializedObject.UpdateIfDirtyOrScript();
-#endif
 
             GUILayout.Space(5);
 

--- a/Editor/InputSources/TuioInputEditor.cs
+++ b/Editor/InputSources/TuioInputEditor.cs
@@ -29,11 +29,7 @@ namespace TouchScript.Editor.InputSources
 
         public override void OnInspectorGUI()
         {
-#if UNITY_5_6_OR_NEWER
 			serializedObject.UpdateIfRequiredOrScript();
-#else
-			serializedObject.UpdateIfDirtyOrScript();
-#endif
 
             EditorGUILayout.PropertyField(tuioPort);
 

--- a/Editor/Layers/FullscreenLayerEditor.cs
+++ b/Editor/Layers/FullscreenLayerEditor.cs
@@ -30,11 +30,7 @@ namespace TouchScript.Editor.Layers
 
         public override void OnInspectorGUI()
         {
-#if UNITY_5_6_OR_NEWER
             serializedObject.UpdateIfRequiredOrScript();
-#else
-            serializedObject.UpdateIfDirtyOrScript();
-#endif
 
             EditorGUILayout.PropertyField(layerName, TEXT_NAME);
             EditorGUI.BeginChangeCheck();

--- a/Editor/Layers/StandardLayerEditor.cs
+++ b/Editor/Layers/StandardLayerEditor.cs
@@ -53,11 +53,7 @@ namespace TouchScript.Editor.Layers
 
         public override void OnInspectorGUI()
         {
-#if UNITY_5_6_OR_NEWER
             serializedObject.UpdateIfRequiredOrScript();
-#else
-			serializedObject.UpdateIfDirtyOrScript();
-#endif
 
             GUILayout.Space(5);
 

--- a/Editor/TouchManagerEditor.cs
+++ b/Editor/TouchManagerEditor.cs
@@ -97,11 +97,7 @@ namespace TouchScript.Editor
 
         public override void OnInspectorGUI()
         {
-#if UNITY_5_6_OR_NEWER
             serializedObject.UpdateIfRequiredOrScript();
-#else
-            serializedObject.UpdateIfDirtyOrScript();
-#endif
 
             GUILayout.Space(5);
 
@@ -207,11 +203,7 @@ namespace TouchScript.Editor
                     var label = EditorGUI.BeginProperty(r, TEXT_SEND_MESSAGE_EVENTS, sendMessageEvents);
                     EditorGUI.BeginChangeCheck();
                     r = EditorGUI.PrefixLabel(r, label);
-#if UNITY_2017_3_OR_NEWER
                     var sMask = (TouchManager.MessageType) EditorGUI.EnumFlagsField(r, instance.SendMessageEvents);
-#else
-                    var sMask = (TouchManager.MessageType) EditorGUI.EnumMaskField(r, instance.SendMessageEvents);
-#endif
                     if (EditorGUI.EndChangeCheck())
                     {
                         instance.SendMessageEvents = sMask;

--- a/Runtime/Behaviors/Cursors/CursorManager.cs
+++ b/Runtime/Behaviors/Cursors/CursorManager.cs
@@ -133,9 +133,7 @@ namespace TouchScript.Behaviors.Cursors
         private ObjectPool<PointerCursor> objectPool;
         private Dictionary<int, PointerCursor> cursors = new Dictionary<int, PointerCursor>(10);
 
-#if UNITY_5_6_OR_NEWER
 		private CustomSampler cursorSampler;
-#endif
 
         #endregion
 
@@ -143,10 +141,8 @@ namespace TouchScript.Behaviors.Cursors
 
         private void Awake()
         {
-#if UNITY_5_6_OR_NEWER
 			cursorSampler = CustomSampler.Create("[TouchScript] Update Cursors");
 			cursorSampler.Begin();
-#endif
 
             mousePool = new ObjectPool<PointerCursor>(2, instantiateMouseProxy, null, clearProxy);
             touchPool = new ObjectPool<PointerCursor>(10, instantiateTouchProxy, null, clearProxy);
@@ -162,9 +158,7 @@ namespace TouchScript.Behaviors.Cursors
                 enabled = false;
             }
 
-#if UNITY_5_6_OR_NEWER
 			cursorSampler.End();
-#endif
         }
 
         private void OnEnable()
@@ -233,9 +227,7 @@ namespace TouchScript.Behaviors.Cursors
 
         private void pointersAddedHandler(object sender, PointerEventArgs e)
         {
-#if UNITY_5_6_OR_NEWER
 			cursorSampler.Begin();
-#endif
 
             updateCursorSize();
 
@@ -270,16 +262,12 @@ namespace TouchScript.Behaviors.Cursors
                 cursors.Add(pointer.Id, cursor);
             }
 
-#if UNITY_5_6_OR_NEWER
 			cursorSampler.End();
-#endif
         }
 
         private void pointersRemovedHandler(object sender, PointerEventArgs e)
         {
-#if UNITY_5_6_OR_NEWER
 			cursorSampler.Begin();
-#endif
 
             var count = e.Pointers.Count;
             for (var i = 0; i < count; i++)
@@ -306,16 +294,12 @@ namespace TouchScript.Behaviors.Cursors
                 }
             }
 
-#if UNITY_5_6_OR_NEWER
 			cursorSampler.End();
-#endif
         }
 
         private void pointersPressedHandler(object sender, PointerEventArgs e)
         {
-#if UNITY_5_6_OR_NEWER
 			cursorSampler.Begin();
-#endif
 
             var count = e.Pointers.Count;
             for (var i = 0; i < count; i++)
@@ -326,16 +310,12 @@ namespace TouchScript.Behaviors.Cursors
                 cursor.SetState(pointer, PointerCursor.CursorState.Pressed);
             }
 
-#if UNITY_5_6_OR_NEWER
 			cursorSampler.End();
-#endif
         }
 
         private void PointersUpdatedHandler(object sender, PointerEventArgs e)
         {
-#if UNITY_5_6_OR_NEWER
 			cursorSampler.Begin();
-#endif
 
             var count = e.Pointers.Count;
             for (var i = 0; i < count; i++)
@@ -346,16 +326,12 @@ namespace TouchScript.Behaviors.Cursors
                 cursor.UpdatePointer(pointer);
             }
 
-#if UNITY_5_6_OR_NEWER
 			cursorSampler.End();
-#endif
         }
 
         private void pointersReleasedHandler(object sender, PointerEventArgs e)
         {
-#if UNITY_5_6_OR_NEWER
 			cursorSampler.Begin();
-#endif
 
             var count = e.Pointers.Count;
             for (var i = 0; i < count; i++)
@@ -366,9 +342,7 @@ namespace TouchScript.Behaviors.Cursors
                 cursor.SetState(pointer, PointerCursor.CursorState.Released);
             }
 
-#if UNITY_5_6_OR_NEWER
 			cursorSampler.End();
-#endif
         }
 
         private void pointersCancelledHandler(object sender, PointerEventArgs e)

--- a/Runtime/Core/GestureManagerInstance.cs
+++ b/Runtime/Core/GestureManagerInstance.cs
@@ -60,9 +60,7 @@ namespace TouchScript.Core
         private List<Gesture> gesturesToReset = new List<Gesture>(20);
         private Dictionary<int, List<Gesture>> pointerToGestures = new Dictionary<int, List<Gesture>>(10);
 
-#if UNITY_5_6_OR_NEWER
 		private CustomSampler gestureSampler;
-#endif
 
         #endregion
 
@@ -114,9 +112,7 @@ namespace TouchScript.Core
             pointerListPool.WarmUp(20);
             transformListPool.WarmUp(1);
 
-#if UNITY_5_6_OR_NEWER
 			gestureSampler = CustomSampler.Create("[TouchScript] Update Gestures");
-#endif
         }
 
         private void OnEnable()
@@ -222,9 +218,7 @@ namespace TouchScript.Core
 
         private void updatePressed(IList<Pointer> pointers)
         {
-#if UNITY_5_6_OR_NEWER
 			gestureSampler.Begin();
-#endif
 
             var activeTargets = transformListPool.Get();
             var gesturesInHierarchy = gestureListPool.Get();
@@ -376,16 +370,12 @@ namespace TouchScript.Core
             activeGesturesThisUpdate.Clear();
             pointersToDispatchForGesture.Clear();
 
-#if UNITY_5_6_OR_NEWER
 			gestureSampler.End();
-#endif
         }
 
         private void updateUpdated(IList<Pointer> pointers)
         {
-#if UNITY_5_6_OR_NEWER
 			gestureSampler.Begin();
-#endif
 
             sortPointersForActiveGestures(pointers);
 
@@ -404,16 +394,12 @@ namespace TouchScript.Core
             activeGesturesThisUpdate.Clear();
             pointersToDispatchForGesture.Clear();
 
-#if UNITY_5_6_OR_NEWER
 			gestureSampler.End();
-#endif
         }
 
         private void updateReleased(IList<Pointer> pointers)
         {
-#if UNITY_5_6_OR_NEWER
 			gestureSampler.Begin();
-#endif
 
             sortPointersForActiveGestures(pointers);
 
@@ -433,16 +419,12 @@ namespace TouchScript.Core
             activeGesturesThisUpdate.Clear();
             pointersToDispatchForGesture.Clear();
 
-#if UNITY_5_6_OR_NEWER
 			gestureSampler.End();
-#endif
         }
 
         private void updateCancelled(IList<Pointer> pointers)
         {
-#if UNITY_5_6_OR_NEWER
 			gestureSampler.Begin();
-#endif
 
             sortPointersForActiveGestures(pointers);
 
@@ -462,9 +444,7 @@ namespace TouchScript.Core
             activeGesturesThisUpdate.Clear();
             pointersToDispatchForGesture.Clear();
 
-#if UNITY_5_6_OR_NEWER
 			gestureSampler.End();
-#endif
         }
 
         private void sortPointersForActiveGestures(IList<Pointer> pointers)

--- a/Runtime/Core/TouchManagerInstance.cs
+++ b/Runtime/Core/TouchManagerInstance.cs
@@ -18,9 +18,7 @@ using TouchScript.Core;
 using TouchScript.Debugging.GL;
 using TouchScript.Debugging.Loggers;
 #endif
-#if UNITY_5_4_OR_NEWER
 using UnityEngine.SceneManagement;
-#endif
 
 namespace TouchScript.Core
 {
@@ -265,9 +263,7 @@ namespace TouchScript.Core
         private IPointerLogger pLogger;
 #endif
 
-#if UNITY_5_6_OR_NEWER
 		private CustomSampler samplerUpdateInputs, samplerUpdateAdded, samplerUpdatePressed, samplerUpdateUpdated, samplerUpdateReleased, samplerUpdateRemoved, samplerUpdateCancelled;
-#endif
 
         #endregion
 
@@ -519,9 +515,7 @@ namespace TouchScript.Core
             pLogger = Debugging.TouchScriptDebugger.Instance.PointerLogger;
 #endif
 
-#if UNITY_5_4_OR_NEWER
             SceneManager.sceneLoaded += sceneLoadedHandler;
-#endif
 
             gameObject.hideFlags = HideFlags.HideInHierarchy;
             DontDestroyOnLoad(gameObject);
@@ -540,7 +534,6 @@ namespace TouchScript.Core
 			_layerRemovePointer = layerRemovePointer;
 			_layerCancelPointer = layerCancelPointer;
 
-#if UNITY_5_6_OR_NEWER
             samplerUpdateInputs = CustomSampler.Create("[TouchScript] Update Inputs");
 			samplerUpdateAdded = CustomSampler.Create("[TouchScript] Added Pointers");
 			samplerUpdatePressed = CustomSampler.Create("[TouchScript] Press Pointers");
@@ -548,22 +541,13 @@ namespace TouchScript.Core
 			samplerUpdateReleased = CustomSampler.Create("[TouchScript] Release Pointers");
 			samplerUpdateRemoved = CustomSampler.Create("[TouchScript] Remove Pointers");
 			samplerUpdateCancelled = CustomSampler.Create("[TouchScript] Cancel Pointers");
-#endif
         }
 
-#if UNITY_5_4_OR_NEWER
         private void sceneLoadedHandler(Scene scene, LoadSceneMode mode)
         {
             StopAllCoroutines();
             StartCoroutine(lateAwake());
         }
-#else
-        private void OnLevelWasLoaded(int value)
-        {
-            StopAllCoroutines();
-            StartCoroutine(lateAwake());
-        }
-#endif
 
         private IEnumerator lateAwake()
         {
@@ -627,20 +611,14 @@ namespace TouchScript.Core
 
         private void updateInputs()
         {
-#if UNITY_5_6_OR_NEWER
             samplerUpdateInputs.Begin();
-#endif
             for (var i = 0; i < inputCount; i++) inputs[i].UpdateInput();
-#if UNITY_5_6_OR_NEWER
             samplerUpdateInputs.End();
-#endif
         }
 
         private void updateAdded(List<Pointer> pointers)
         {
-#if UNITY_5_6_OR_NEWER
 			samplerUpdateAdded.Begin();
-#endif
 
             var addedCount = pointers.Count;
             var list = pointerListPool.Get();
@@ -668,9 +646,7 @@ namespace TouchScript.Core
                 pointersAddedInvoker.InvokeHandleExceptions(this, PointerEventArgs.GetCachedEventArgs(list));
             pointerListPool.Release(list);
 
-#if UNITY_5_6_OR_NEWER
 			samplerUpdateAdded.End();
-#endif
         }
 
         private bool layerAddPointer(TouchLayer layer)
@@ -681,9 +657,7 @@ namespace TouchScript.Core
 
         private void updateUpdated(List<int> pointers)
         {
-#if UNITY_5_6_OR_NEWER
 			samplerUpdateUpdated.Begin();
-#endif
 
             var updatedCount = pointers.Count;
             var list = pointerListPool.Get();
@@ -724,9 +698,7 @@ namespace TouchScript.Core
                 pointersUpdatedInvoker.InvokeHandleExceptions(this, PointerEventArgs.GetCachedEventArgs(list));
             pointerListPool.Release(list);
 
-#if UNITY_5_6_OR_NEWER
 			samplerUpdateUpdated.End();
-#endif
         }
 
         private bool layerUpdatePointer(TouchLayer layer)
@@ -737,9 +709,7 @@ namespace TouchScript.Core
 
         private void updatePressed(List<int> pointers)
         {
-#if UNITY_5_6_OR_NEWER
 			samplerUpdatePressed.Begin();
-#endif
 
             var pressedCount = pointers.Count;
             var list = pointerListPool.Get();
@@ -776,16 +746,12 @@ namespace TouchScript.Core
                 pointersPressedInvoker.InvokeHandleExceptions(this, PointerEventArgs.GetCachedEventArgs(list));
             pointerListPool.Release(list);
 
-#if UNITY_5_6_OR_NEWER
 			samplerUpdatePressed.End();
-#endif
         }
 
         private void updateReleased(List<int> pointers)
         {
-#if UNITY_5_6_OR_NEWER
 			samplerUpdateReleased.Begin();
-#endif
 
             var releasedCount = pointers.Count;
             var list = pointerListPool.Get();
@@ -826,16 +792,12 @@ namespace TouchScript.Core
             }
             pointerListPool.Release(list);
 
-#if UNITY_5_6_OR_NEWER
 			samplerUpdateReleased.End();
-#endif
         }
 
         private void updateRemoved(List<int> pointers)
         {
-#if UNITY_5_6_OR_NEWER
 			samplerUpdateRemoved.Begin();
-#endif
 
             var removedCount = pointers.Count;
             var list = pointerListPool.Get();
@@ -879,9 +841,7 @@ namespace TouchScript.Core
             }
             pointerListPool.Release(list);
 
-#if UNITY_5_6_OR_NEWER
 			samplerUpdateRemoved.End();
-#endif
         }
 
         private bool layerRemovePointer(TouchLayer layer)
@@ -892,9 +852,7 @@ namespace TouchScript.Core
 
         private void updateCancelled(List<int> pointers)
         {
-#if UNITY_5_6_OR_NEWER
 			samplerUpdateCancelled.Begin();
-#endif
 
             var cancelledCount = pointers.Count;
             var list = pointerListPool.Get();
@@ -939,9 +897,7 @@ namespace TouchScript.Core
             }
             pointerListPool.Release(list);
 
-#if UNITY_5_6_OR_NEWER
 			samplerUpdateCancelled.End();
-#endif
         }
 
         private bool layerCancelPointer(TouchLayer layer)

--- a/Runtime/Devices/Display/DisplayDevice.cs
+++ b/Runtime/Devices/Display/DisplayDevice.cs
@@ -13,18 +13,9 @@ namespace TouchScript.Devices.Display
     /// A simple display device which inherits from <see cref="ScriptableObject"/> and can be saved in Unity assets.
     /// </summary>
     [HelpURL("http://touchscript.github.io/docs/html/T_TouchScript_Devices_Display_DisplayDevice.htm")]
+    [CreateAssetMenu(fileName = "DisplayDevice", menuName = "TouchScript/New Display Device", order = 0)]
     public class DisplayDevice : ScriptableObject, IDisplayDevice
     {
-#if UNITY_EDITOR
-        //[MenuItem("Window/TouchScript/CreateDisplayDevice")]
-        private static DisplayDevice CreateDisplayDevice()
-        {
-            var dd = CreateInstance<DisplayDevice>();
-            AssetDatabase.CreateAsset(dd, "Assets/DisplayDevice.asset");
-            return dd;
-        }
-#endif
-
         /// <inheritdoc />
         public string Name
         {

--- a/Runtime/Devices/Display/GenericDisplayDevice.cs
+++ b/Runtime/Devices/Display/GenericDisplayDevice.cs
@@ -103,9 +103,7 @@ namespace TouchScript.Devices.Display
                     break;
                 // Probably TVs
                 case RuntimePlatform.SamsungTVPlayer:
-#if UNITY_5_6_OR_NEWER
                 case RuntimePlatform.Switch:
-#endif
                 case RuntimePlatform.WiiU:
                 case RuntimePlatform.XboxOne:
                 case RuntimePlatform.tvOS:
@@ -200,9 +198,7 @@ namespace TouchScript.Devices.Display
                     break;
                 // Probably TVs
                 case RuntimePlatform.SamsungTVPlayer:
-#if UNITY_5_6_OR_NEWER
                 case RuntimePlatform.Switch:
-#endif
                 case RuntimePlatform.WiiU:
                 case RuntimePlatform.XboxOne:
                 case RuntimePlatform.tvOS:

--- a/Runtime/Gestures/FlickGesture.cs
+++ b/Runtime/Gestures/FlickGesture.cs
@@ -138,9 +138,7 @@ namespace TouchScript.Gestures
         private bool isActive = false;
         private TimedSequence<Vector2> deltaSequence = new TimedSequence<Vector2>();
 
-#if UNITY_5_6_OR_NEWER
 		private CustomSampler gestureSampler;
-#endif
 
         #endregion
 
@@ -151,9 +149,7 @@ namespace TouchScript.Gestures
 		{
 			base.Awake();
 
-#if UNITY_5_6_OR_NEWER
 			gestureSampler = CustomSampler.Create("[TouchScript] Flick Gesture");
-#endif
 		}
 
         /// <inheritdoc />
@@ -177,9 +173,7 @@ namespace TouchScript.Gestures
         /// <inheritdoc />
         protected override void pointersPressed(IList<Pointer> pointers)
         {
-#if UNITY_5_6_OR_NEWER
 			gestureSampler.Begin();
-#endif
 
             base.pointersPressed(pointers);
 
@@ -195,17 +189,13 @@ namespace TouchScript.Gestures
                 else isActive = true;
             }
 
-#if UNITY_5_6_OR_NEWER
 			gestureSampler.End();
-#endif
         }
 
         /// <inheritdoc />
         protected override void pointersUpdated(IList<Pointer> pointers)
         {
-#if UNITY_5_6_OR_NEWER
 			gestureSampler.Begin();
-#endif
 
             base.pointersUpdated(pointers);
 
@@ -219,17 +209,13 @@ namespace TouchScript.Gestures
                 }
             }
 
-#if UNITY_5_6_OR_NEWER
 			gestureSampler.End();
-#endif
         }
 
         /// <inheritdoc />
         protected override void pointersReleased(IList<Pointer> pointers)
         {
-#if UNITY_5_6_OR_NEWER
 			gestureSampler.Begin();
-#endif
 
             base.pointersReleased(pointers);
 
@@ -238,9 +224,7 @@ namespace TouchScript.Gestures
                 if (!isActive || !moving)
                 {
                     setState(GestureState.Failed);
-#if UNITY_5_6_OR_NEWER
 					gestureSampler.End();
-#endif
                     return;
                 }
 
@@ -274,9 +258,7 @@ namespace TouchScript.Gestures
                 }
             }
 
-#if UNITY_5_6_OR_NEWER
 			gestureSampler.End();
-#endif
         }
 
         /// <inheritdoc />

--- a/Runtime/Gestures/LongPressGesture.cs
+++ b/Runtime/Gestures/LongPressGesture.cs
@@ -91,10 +91,8 @@ namespace TouchScript.Gestures
 
         private Vector2 totalMovement;
 
-#if UNITY_5_6_OR_NEWER
 		private CustomSampler gestureSampler;
-#endif
-
+      
         #endregion
 
         #region Unity methods
@@ -104,9 +102,7 @@ namespace TouchScript.Gestures
 		{
 			base.Awake();
 
-#if UNITY_5_6_OR_NEWER
 			gestureSampler = CustomSampler.Create("[TouchScript] Long Press Gesture");
-#endif
 		}
 
         /// <inheritdoc />
@@ -130,9 +126,7 @@ namespace TouchScript.Gestures
         /// <inheritdoc />
         protected override void pointersPressed(IList<Pointer> pointers)
         {
-#if UNITY_5_6_OR_NEWER
 			gestureSampler.Begin();
-#endif
 
             base.pointersPressed(pointers);
 
@@ -147,17 +141,13 @@ namespace TouchScript.Gestures
                 StartCoroutine("wait");
             }
 
-#if UNITY_5_6_OR_NEWER
 			gestureSampler.End();
-#endif
         }
 
         /// <inheritdoc />
         protected override void pointersUpdated(IList<Pointer> pointers)
         {
-#if UNITY_5_6_OR_NEWER
 			gestureSampler.Begin();
-#endif
 
             base.pointersUpdated(pointers);
 
@@ -167,17 +157,13 @@ namespace TouchScript.Gestures
                 if (totalMovement.sqrMagnitude > distanceLimitInPixelsSquared) setState(GestureState.Failed);
             }
 
-#if UNITY_5_6_OR_NEWER
 			gestureSampler.End();
-#endif
         }
 
         /// <inheritdoc />
         protected override void pointersReleased(IList<Pointer> pointers)
         {
-#if UNITY_5_6_OR_NEWER
 			gestureSampler.Begin();
-#endif
 
             base.pointersReleased(pointers);
 
@@ -186,9 +172,7 @@ namespace TouchScript.Gestures
                 setState(GestureState.Failed);
             }
 
-#if UNITY_5_6_OR_NEWER
 			gestureSampler.End();
-#endif
         }
 
         /// <inheritdoc />

--- a/Runtime/Gestures/MetaGesture.cs
+++ b/Runtime/Gestures/MetaGesture.cs
@@ -90,9 +90,7 @@ namespace TouchScript.Gestures
 
 		#region Private variables
 
-#if UNITY_5_6_OR_NEWER
 		private CustomSampler gestureSampler;
-#endif
 
 		#endregion
 
@@ -103,9 +101,7 @@ namespace TouchScript.Gestures
 		{
 			base.Awake();
 
-#if UNITY_5_6_OR_NEWER
 			gestureSampler = CustomSampler.Create("[TouchScript] Meta Gesture");
-#endif
 		}
 
 		[ContextMenu("Basic Editor")]
@@ -121,9 +117,7 @@ namespace TouchScript.Gestures
 		/// <inheritdoc />
 		protected override void pointersPressed(IList<Pointer> pointers)
         {
-#if UNITY_5_6_OR_NEWER
 			gestureSampler.Begin();
-#endif
 
             base.pointersPressed(pointers);
 
@@ -140,17 +134,13 @@ namespace TouchScript.Gestures
                 for (var i = 0; i < length; i++) SendMessageTarget.SendMessage(POINTER_PRESSED_MESSAGE, pointers[i], SendMessageOptions.DontRequireReceiver);
             }
 
-#if UNITY_5_6_OR_NEWER
 			gestureSampler.End();
-#endif
         }
 
         /// <inheritdoc />
         protected override void pointersUpdated(IList<Pointer> pointers)
         {
-#if UNITY_5_6_OR_NEWER
 			gestureSampler.Begin();
-#endif
 
             base.pointersUpdated(pointers);
 
@@ -167,17 +157,13 @@ namespace TouchScript.Gestures
                 for (var i = 0; i < length; i++) SendMessageTarget.SendMessage(POINTER_MOVED_MESSAGE, pointers[i], SendMessageOptions.DontRequireReceiver);
             }
 
-#if UNITY_5_6_OR_NEWER
 			gestureSampler.End();
-#endif
         }
 
         /// <inheritdoc />
         protected override void pointersReleased(IList<Pointer> pointers)
         {
-#if UNITY_5_6_OR_NEWER
 			gestureSampler.Begin();
-#endif
 
             base.pointersReleased(pointers);
 
@@ -194,17 +180,13 @@ namespace TouchScript.Gestures
                 for (var i = 0; i < length; i++) SendMessageTarget.SendMessage(POINTER_RELEASED_MESSAGE, pointers[i], SendMessageOptions.DontRequireReceiver);
             }
 
-#if UNITY_5_6_OR_NEWER
 			gestureSampler.End();
-#endif
         }
 
         /// <inheritdoc />
         protected override void pointersCancelled(IList<Pointer> pointers)
         {
-#if UNITY_5_6_OR_NEWER
 			gestureSampler.Begin();
-#endif
 
             base.pointersCancelled(pointers);
 
@@ -219,9 +201,7 @@ namespace TouchScript.Gestures
                 for (var i = 0; i < length; i++) SendMessageTarget.SendMessage(POINTER_CANCELLED_MESSAGE, pointers[i], SendMessageOptions.DontRequireReceiver);
             }
 
-#if UNITY_5_6_OR_NEWER
 			gestureSampler.End();
-#endif
         }
 
         #endregion

--- a/Runtime/Gestures/PressGesture.cs
+++ b/Runtime/Gestures/PressGesture.cs
@@ -75,9 +75,7 @@ namespace TouchScript.Gestures
         [ToggleLeft]
         private bool ignoreChildren = false;
 
-#if UNITY_5_6_OR_NEWER
         private CustomSampler gestureSampler;
-#endif
 
         #endregion
 
@@ -88,9 +86,7 @@ namespace TouchScript.Gestures
         {
             base.Awake();
 
-#if UNITY_5_6_OR_NEWER
             gestureSampler = CustomSampler.Create("[TouchScript] Press Gesture");
-#endif
         }
 
         [ContextMenu("Basic Editor")]
@@ -130,32 +126,24 @@ namespace TouchScript.Gestures
         /// <inheritdoc />
         protected override void pointersPressed(IList<Pointer> pointers)
         {
-#if UNITY_5_6_OR_NEWER
             gestureSampler.Begin();
-#endif
 
             base.pointersPressed(pointers);
 
             if (pointersNumState == PointersNumState.PassedMinThreshold)
             {
                 setState(GestureState.Recognized);
-#if UNITY_5_6_OR_NEWER
                 gestureSampler.End();
-#endif
                 return;
             }
             if (pointersNumState == PointersNumState.PassedMinMaxThreshold)
             {
                 setState(GestureState.Failed);
-#if UNITY_5_6_OR_NEWER
                 gestureSampler.End();
-#endif
                 return;
             }
 
-#if UNITY_5_6_OR_NEWER
             gestureSampler.End();
-#endif
         }
 
         /// <inheritdoc />

--- a/Runtime/Gestures/ReleaseGesture.cs
+++ b/Runtime/Gestures/ReleaseGesture.cs
@@ -70,9 +70,7 @@ namespace TouchScript.Gestures
         [ToggleLeft]
         private bool ignoreChildren = false;
 
-#if UNITY_5_6_OR_NEWER
 		private CustomSampler gestureSampler;
-#endif
 
 		#endregion
 
@@ -83,9 +81,7 @@ namespace TouchScript.Gestures
 		{
 			base.Awake();
 
-#if UNITY_5_6_OR_NEWER
 			gestureSampler = CustomSampler.Create("[TouchScript] Release Gesture");
-#endif
 		}
 
 		[ContextMenu("Basic Editor")]
@@ -125,48 +121,36 @@ namespace TouchScript.Gestures
         /// <inheritdoc />
         protected override void pointersPressed(IList<Pointer> pointers)
         {
-#if UNITY_5_6_OR_NEWER
 			gestureSampler.Begin();
-#endif
 
             base.pointersPressed(pointers);
 
             if (pointersNumState == PointersNumState.PassedMinThreshold)
             {
                 if (State == GestureState.Idle) setState(GestureState.Possible);
-#if UNITY_5_6_OR_NEWER
 				gestureSampler.End();
-#endif
                 return;
             }
             if (pointersNumState == PointersNumState.PassedMinMaxThreshold)
             {
                 setState(GestureState.Failed);
-#if UNITY_5_6_OR_NEWER
 				gestureSampler.End();
-#endif
                 return;
             }
 
-#if UNITY_5_6_OR_NEWER
 			gestureSampler.End();
-#endif
         }
 
         /// <inheritdoc />
         protected override void pointersReleased(IList<Pointer> pointers)
         {
-#if UNITY_5_6_OR_NEWER
 			gestureSampler.Begin();
-#endif
 
             base.pointersReleased(pointers);
 
             if (pointersNumState == PointersNumState.PassedMinThreshold) setState(GestureState.Recognized);
 
-#if UNITY_5_6_OR_NEWER
 			gestureSampler.End();
-#endif
         }
 
         /// <inheritdoc />

--- a/Runtime/Gestures/TapGesture.cs
+++ b/Runtime/Gestures/TapGesture.cs
@@ -145,9 +145,7 @@ namespace TouchScript.Gestures
         private Vector2 totalMovement;
         private TimedSequence<Pointer> pointerSequence = new TimedSequence<Pointer>();
 
-#if UNITY_5_6_OR_NEWER
         private CustomSampler gestureSampler;
-#endif
 
         #endregion
 
@@ -171,9 +169,7 @@ namespace TouchScript.Gestures
         {
             base.Awake();
 
-#if UNITY_5_6_OR_NEWER
             gestureSampler = CustomSampler.Create("[TouchScript] Tap Gesture");
-#endif
         }
 
         /// <inheritdoc />
@@ -197,9 +193,7 @@ namespace TouchScript.Gestures
         /// <inheritdoc />
         protected override void pointersPressed(IList<Pointer> pointers)
         {
-#if UNITY_5_6_OR_NEWER
             gestureSampler.Begin();
-#endif
 
             base.pointersPressed(pointers);
 
@@ -207,9 +201,7 @@ namespace TouchScript.Gestures
                 pointersNumState == PointersNumState.PassedMinMaxThreshold)
             {
                 setState(GestureState.Failed);
-#if UNITY_5_6_OR_NEWER
                 gestureSampler.End();
-#endif
                 return;
             }
 
@@ -234,9 +226,7 @@ namespace TouchScript.Gestures
                         if ((pointers[0].Position - startPosition).sqrMagnitude > distanceLimitInPixelsSquared)
                         {
                             setState(GestureState.Failed);
-#if UNITY_5_6_OR_NEWER
                             gestureSampler.End();
-#endif
                             return;
                         }
                     }
@@ -253,17 +243,13 @@ namespace TouchScript.Gestures
                 }
             }
 
-#if UNITY_5_6_OR_NEWER
             gestureSampler.End();
-#endif
         }
 
         /// <inheritdoc />
         protected override void pointersUpdated(IList<Pointer> pointers)
         {
-#if UNITY_5_6_OR_NEWER
             gestureSampler.Begin();
-#endif
 
             base.pointersUpdated(pointers);
 
@@ -273,17 +259,13 @@ namespace TouchScript.Gestures
                 if (totalMovement.sqrMagnitude > distanceLimitInPixelsSquared) setState(GestureState.Failed);
             }
 
-#if UNITY_5_6_OR_NEWER
             gestureSampler.End();
-#endif
         }
 
         /// <inheritdoc />
         protected override void pointersReleased(IList<Pointer> pointers)
         {
-#if UNITY_5_6_OR_NEWER
             gestureSampler.Begin();
-#endif
 
             base.pointersReleased(pointers);
 
@@ -307,9 +289,7 @@ namespace TouchScript.Gestures
                     if (!isActive)
                     {
                         setState(GestureState.Failed);
-#if UNITY_5_6_OR_NEWER
                         gestureSampler.End();
-#endif
                         return;
                     }
 
@@ -328,9 +308,7 @@ namespace TouchScript.Gestures
                 }
             }
 
-#if UNITY_5_6_OR_NEWER
             gestureSampler.End();
-#endif
         }
 
         /// <inheritdoc />

--- a/Runtime/Gestures/TransformGestures/PinnedTransformGesture.cs
+++ b/Runtime/Gestures/TransformGestures/PinnedTransformGesture.cs
@@ -89,9 +89,7 @@ namespace TouchScript.Gestures.TransformGestures
         private TouchLayer projectionLayer;
         private Plane transformPlane;
 
-#if UNITY_5_6_OR_NEWER
 		private CustomSampler gestureSampler;
-#endif
 
         #endregion
 
@@ -107,9 +105,7 @@ namespace TouchScript.Gestures.TransformGestures
             base.Awake();
 
             transformPlane = new Plane();
-#if UNITY_5_6_OR_NEWER
 			gestureSampler = CustomSampler.Create("[TouchScript] Pinned Transform Gesture");
-#endif
         }
 
         /// <inheritdoc />
@@ -133,9 +129,7 @@ namespace TouchScript.Gestures.TransformGestures
         /// <inheritdoc />
         protected override void pointersPressed(IList<Pointer> pointers)
         {
-#if UNITY_5_6_OR_NEWER
 			gestureSampler.Begin();
-#endif
 
             base.pointersPressed(pointers);
 
@@ -149,12 +143,9 @@ namespace TouchScript.Gestures.TransformGestures
 #endif
             }
 
-#if UNITY_5_6_OR_NEWER
 			gestureSampler.End();
-#endif
         }
 
-#if UNITY_5_6_OR_NEWER
 		/// <inheritdoc />
 		protected override void pointersUpdated(IList<Pointer> pointers)
 		{
@@ -164,14 +155,11 @@ namespace TouchScript.Gestures.TransformGestures
 
 			gestureSampler.End();
 		}
-#endif
 
         /// <inheritdoc />
         protected override void pointersReleased(IList<Pointer> pointers)
         {
-#if UNITY_5_6_OR_NEWER
 			gestureSampler.Begin();
-#endif
 
             base.pointersReleased(pointers);
 
@@ -179,9 +167,7 @@ namespace TouchScript.Gestures.TransformGestures
             if (NumPointers == 0) clearDebug();
             else drawDebug(activePointers[0].ProjectionParams.ProjectFrom(cachedTransform.position), activePointers[0].Position);
 #endif
-#if UNITY_5_6_OR_NEWER
 			gestureSampler.End();
-#endif
         }
 
         #endregion

--- a/Runtime/Gestures/TransformGestures/ScreenTransformGesture.cs
+++ b/Runtime/Gestures/TransformGestures/ScreenTransformGesture.cs
@@ -22,9 +22,7 @@ namespace TouchScript.Gestures.TransformGestures
 
 		#region Private variables
 
-#if UNITY_5_6_OR_NEWER
 		private CustomSampler gestureSampler;
-#endif
 
 		#endregion
 
@@ -35,9 +33,7 @@ namespace TouchScript.Gestures.TransformGestures
 		{
 			base.Awake();
 
-#if UNITY_5_6_OR_NEWER
 			gestureSampler = CustomSampler.Create("[TouchScript] Screen Transform Gesture");
-#endif
 		}
 
 		[ContextMenu("Basic Editor")]
@@ -50,7 +46,6 @@ namespace TouchScript.Gestures.TransformGestures
 
         #region Gesture callbacks
 
-#if UNITY_5_6_OR_NEWER
 		/// <inheritdoc />
 		protected override void pointersPressed(IList<Pointer> pointers)
 		{
@@ -70,14 +65,11 @@ namespace TouchScript.Gestures.TransformGestures
 
 			gestureSampler.End();
 		}
-#endif
 
         /// <inheritdoc />
         protected override void pointersReleased(IList<Pointer> pointers)
         {
-#if UNITY_5_6_OR_NEWER
 			gestureSampler.Begin();
-#endif
 
             base.pointersReleased(pointers);
 
@@ -86,9 +78,7 @@ namespace TouchScript.Gestures.TransformGestures
             else drawDebugDelayed(getNumPoints());
 #endif
 
-#if UNITY_5_6_OR_NEWER
 			gestureSampler.End();
-#endif
         }
 
         #endregion

--- a/Runtime/Gestures/TransformGestures/TransformGesture.cs
+++ b/Runtime/Gestures/TransformGestures/TransformGesture.cs
@@ -147,9 +147,7 @@ namespace TouchScript.Gestures.TransformGestures
         private TouchLayer projectionLayer;
         private Plane transformPlane;
 
-#if UNITY_5_6_OR_NEWER
 		private CustomSampler gestureSampler;
-#endif
 
         #endregion
 
@@ -165,9 +163,7 @@ namespace TouchScript.Gestures.TransformGestures
             base.Awake();
 
             transformPlane = new Plane();
-#if UNITY_5_6_OR_NEWER
 			gestureSampler = CustomSampler.Create("[TouchScript] Transform Gesture");
-#endif
         }
 
         /// <inheritdoc />
@@ -191,9 +187,7 @@ namespace TouchScript.Gestures.TransformGestures
         /// <inheritdoc />
         protected override void pointersPressed(IList<Pointer> pointers)
         {
-#if UNITY_5_6_OR_NEWER
 			gestureSampler.Begin();
-#endif
 
             base.pointersPressed(pointers);
 
@@ -203,12 +197,9 @@ namespace TouchScript.Gestures.TransformGestures
                 updateProjectionPlane();
             }
 
-#if UNITY_5_6_OR_NEWER
 			gestureSampler.End();
-#endif
         }
 
-#if UNITY_5_6_OR_NEWER
 		/// <inheritdoc />
 		protected override void pointersUpdated(IList<Pointer> pointers)
 		{
@@ -218,14 +209,11 @@ namespace TouchScript.Gestures.TransformGestures
 
 			gestureSampler.End();
 		}
-#endif
 
         /// <inheritdoc />
         protected override void pointersReleased(IList<Pointer> pointers)
         {
-#if UNITY_5_6_OR_NEWER
 			gestureSampler.Begin();
-#endif
 
             base.pointersReleased(pointers);
 
@@ -234,9 +222,7 @@ namespace TouchScript.Gestures.TransformGestures
             else drawDebugDelayed(getNumPoints());
 #endif
 
-#if UNITY_5_6_OR_NEWER
 			gestureSampler.End();
-#endif
         }
 
 

--- a/Runtime/InputSources/InputHandlers/TouchHandler.cs
+++ b/Runtime/InputSources/InputHandlers/TouchHandler.cs
@@ -48,9 +48,7 @@ namespace TouchScript.InputSources.InputHandlers
         private Dictionary<int, TouchState> systemToInternalId = new Dictionary<int, TouchState>(10);
         private int pointersNum;
 
-#if UNITY_5_6_OR_NEWER
 		private CustomSampler updateSampler;
-#endif
 
         #endregion
 
@@ -77,9 +75,7 @@ namespace TouchScript.InputSources.InputHandlers
             touchPool = new ObjectPool<TouchPointer>(10, newPointer, null, resetPointer, "TouchHandler/Touch");
             touchPool.Name = "Touch";
 
-#if UNITY_5_6_OR_NEWER
 			updateSampler = CustomSampler.Create("[TouchScript] Update Touch");
-#endif
         }
 
         #region Public methods
@@ -87,9 +83,7 @@ namespace TouchScript.InputSources.InputHandlers
         /// <inheritdoc />
         public bool UpdateInput()
         {
-#if UNITY_5_6_OR_NEWER
 			updateSampler.Begin();
-#endif
 
             for (var i = 0; i < Input.touchCount; ++i)
             {
@@ -164,9 +158,7 @@ namespace TouchScript.InputSources.InputHandlers
                 }
             }
 
-#if UNITY_5_6_OR_NEWER
 			updateSampler.End();
-#endif
 
             return Input.touchCount > 0;
         }

--- a/Runtime/Layers/StandardLayer.cs
+++ b/Runtime/Layers/StandardLayer.cs
@@ -135,9 +135,7 @@ namespace TouchScript.Layers
         private static List<RaycastHitUI> raycastHitUIList = new List<RaycastHitUI>(20);
         private static List<RaycastHit> raycastHitList = new List<RaycastHit>(20);
         private static List<HitData> hitList = new List<HitData>(20);
-#if UNITY_5_3_OR_NEWER
         private static RaycastHit[] raycastHits = new RaycastHit[20];
-#endif
         private static RaycastHit2D[] raycastHits2D = new RaycastHit2D[20];
 
 #pragma warning disable 0414
@@ -353,12 +351,7 @@ namespace TouchScript.Layers
 
             if (hit3DObjects)
             {
-#if UNITY_5_3_OR_NEWER
                 count = Physics.RaycastNonAlloc(ray, raycastHits, float.PositiveInfinity, layerMask);
-#else
-                var raycastHits = Physics.RaycastAll(ray, float.PositiveInfinity, layerMask);
-                var count = raycastHits.Length;
-#endif
 
                 // Try to do some optimizations if 2D and WS UI are not required
                 if (!hit2DObjects && !hitWorldSpaceUI)

--- a/Runtime/Layers/UI/TouchScriptInputModule.cs
+++ b/Runtime/Layers/UI/TouchScriptInputModule.cs
@@ -232,17 +232,13 @@ namespace TouchScript.Layers.UI
         {
             protected TouchScriptInputModule input;
 
-#if UNITY_5_6_OR_NEWER
 			private CustomSampler uiSampler;
-#endif
 
             public UIStandardInputModule(TouchScriptInputModule input)
             {
                 this.input = input;
 
-#if UNITY_5_6_OR_NEWER
 				uiSampler = CustomSampler.Create("[TouchScript] Update UI");
-#endif
             }
 
             #region Unchanged from PointerInputModule
@@ -437,9 +433,7 @@ namespace TouchScript.Layers.UI
 
             public virtual void ProcessAdded(object sender, PointerEventArgs pointerEventArgs)
             {
-#if UNITY_5_6_OR_NEWER
                 uiSampler.Begin();
-#endif
 
                 var pointers = pointerEventArgs.Pointers;
                 var raycast = new RaycastResult();
@@ -467,16 +461,12 @@ namespace TouchScript.Layers.UI
                     input.HandlePointerExitAndEnter(data, currentOverGo);
                 }
 
-#if UNITY_5_6_OR_NEWER
                 uiSampler.End();
-#endif
             }
 
             public virtual void ProcessUpdated(object sender, PointerEventArgs pointerEventArgs)
             {
-#if UNITY_5_6_OR_NEWER
 				uiSampler.Begin();
-#endif
 
                 var pointers = pointerEventArgs.Pointers;
                 var raycast = new RaycastResult();
@@ -550,16 +540,12 @@ namespace TouchScript.Layers.UI
                     }
                 }
 
-#if UNITY_5_6_OR_NEWER
 				uiSampler.End();
-#endif
             }
 
             public virtual void ProcessPressed(object sender, PointerEventArgs pointerEventArgs)
             {
-#if UNITY_5_6_OR_NEWER
 				uiSampler.Begin();
-#endif
 
                 var pointers = pointerEventArgs.Pointers;
                 var count = pointers.Count;
@@ -633,16 +619,12 @@ namespace TouchScript.Layers.UI
                         ExecuteEvents.Execute(data.pointerDrag, data, ExecuteEvents.initializePotentialDrag);
                 }
 
-#if UNITY_5_6_OR_NEWER
 				uiSampler.End();
-#endif
             }
 
             public virtual void ProcessReleased(object sender, PointerEventArgs pointerEventArgs)
             {
-#if UNITY_5_6_OR_NEWER
 				uiSampler.Begin();
-#endif
 
                 var pointers = pointerEventArgs.Pointers;
                 var count = pointers.Count;
@@ -696,16 +678,12 @@ namespace TouchScript.Layers.UI
                     }
                 }
 
-#if UNITY_5_6_OR_NEWER
 				uiSampler.End();
-#endif
             }
 
             public virtual void ProcessCancelled(object sender, PointerEventArgs pointerEventArgs)
             {
-#if UNITY_5_6_OR_NEWER
 				uiSampler.Begin();
-#endif
 
                 var pointers = pointerEventArgs.Pointers;
                 var count = pointers.Count;
@@ -742,16 +720,12 @@ namespace TouchScript.Layers.UI
                     data.pointerEnter = null;
                 }
 
-#if UNITY_5_6_OR_NEWER
 				uiSampler.End();
-#endif
             }
 
             public virtual void ProcessRemoved(object sender, PointerEventArgs pointerEventArgs)
             {
-#if UNITY_5_6_OR_NEWER
 				uiSampler.Begin();
-#endif
 
                 var pointers = pointerEventArgs.Pointers;
                 var count = pointers.Count;
@@ -770,9 +744,7 @@ namespace TouchScript.Layers.UI
                     RemovePointerData(pointer.Id);
                 }
 
-#if UNITY_5_6_OR_NEWER
 				uiSampler.End();
-#endif
             }
 
             #endregion

--- a/Samples~/_misc/Scripts/Runner.cs
+++ b/Samples~/_misc/Scripts/Runner.cs
@@ -9,10 +9,7 @@ using System.Collections;
 using UnityEditor;
 using System;
 #endif
-#if UNITY_5_3_OR_NEWER
 using UnityEngine.SceneManagement;
-
-#endif
 
 namespace TouchScript.Examples
 {
@@ -24,33 +21,19 @@ namespace TouchScript.Examples
 
         public void LoadLevel(string name)
         {
-#if UNITY_5_3_OR_NEWER
             SceneManager.LoadScene(name);
-#else
-			Application.LoadLevel(name);
-#endif
         }
 
         public void LoadNextLevel()
         {
-#if UNITY_5_3_OR_NEWER
             SceneManager.LoadScene((SceneManager.GetActiveScene().buildIndex + 1) % SceneManager.sceneCountInBuildSettings);
-#else
-			Application.LoadLevel((Application.loadedLevel + 1)%Application.levelCount);
-#endif
         }
 
         public void LoadPreviousLevel()
         {
-#if UNITY_5_3_OR_NEWER
             var newLevel = SceneManager.GetActiveScene().buildIndex - 1;
             if (newLevel == 0) newLevel = SceneManager.sceneCountInBuildSettings - 1;
             SceneManager.LoadScene(newLevel);
-#else
-			var newLevel = Application.loadedLevel - 1;
-			if (newLevel == 0) newLevel = Application.levelCount - 1;
-			Application.LoadLevel(newLevel);
-#endif
         }
 
         private void Start()
@@ -84,15 +67,9 @@ namespace TouchScript.Examples
             }
 #endif
 
-#if UNITY_5_4_OR_NEWER
             SceneManager.sceneLoaded += sceneLoadedHandler;
-#endif
 
-#if UNITY_5_3_OR_NEWER
             if (SceneManager.GetActiveScene().name == "Examples" && SceneManager.sceneCountInBuildSettings > 1)
-#else
-			if (Application.loadedLevelName == "Examples" && Application.levelCount > 1)
-#endif
             {
                 LoadNextLevel();
             }
@@ -100,9 +77,7 @@ namespace TouchScript.Examples
 
         private void OnDestroy()
         {
-#if UNITY_5_4_OR_NEWER
             SceneManager.sceneLoaded -= sceneLoadedHandler;
-#endif
         }
 
         private void Update()
@@ -110,17 +85,10 @@ namespace TouchScript.Examples
             if (Input.GetKeyDown(KeyCode.Escape)) Application.Quit();
         }
 
-#if UNITY_5_4_OR_NEWER
         private void sceneLoadedHandler(Scene scene, LoadSceneMode mode)
         {
             StartCoroutine(resetUILayer());
         }
-#else
-        private void OnLevelWasLoaded(int num)
-        {
-			StartCoroutine(resetUILayer());
-        }
-#endif
 
         private IEnumerator resetUILayer()
         {

--- a/Samples~/_misc/Scripts/Runner.cs
+++ b/Samples~/_misc/Scripts/Runner.cs
@@ -47,7 +47,7 @@ namespace TouchScript.Examples
             layer = GetComponent<TouchLayer>();
 
 #if UNITY_EDITOR
-            var guids = AssetDatabase.FindAssets("t:Scene", new string[] {"Assets/TouchScript/Examples"});
+            var guids = AssetDatabase.FindAssets("t:Scene", new string[] {"Packages/com.interactive-scape.touchscript/Samples~"});
             if (EditorBuildSettings.scenes.Length != guids.Length)
             {
                 if (EditorUtility.DisplayDialog("Add Example Scenes to Build Settings?",

--- a/Tests.meta
+++ b/Tests.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8f929d7a5e598634da8ab005f935caf1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor.meta
+++ b/Tests/Editor.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8192ac839752d7441a16ff59cf327057
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Editor/EditorTestExample.cs
+++ b/Tests/Editor/EditorTestExample.cs
@@ -1,0 +1,14 @@
+﻿using NUnit.Framework;
+
+namespace TouchScript.Tests
+{
+    public class EditorTestExample
+    {
+        [Test]
+        public void TestString()
+        {
+            string foo = "bar";
+            Assert.AreEqual("bar", foo);
+        }
+    }
+}

--- a/Tests/Editor/EditorTestExample.cs.meta
+++ b/Tests/Editor/EditorTestExample.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: b79ddd3458234a73971970688789002d
+timeCreated: 1679923331

--- a/Tests/Editor/InteractiveScape.TouchScript.Editor.Tests.asmdef
+++ b/Tests/Editor/InteractiveScape.TouchScript.Editor.Tests.asmdef
@@ -1,0 +1,24 @@
+{
+    "name": "InteractiveScape.TouchScript.Editor.Tests",
+    "rootNamespace": "TouchScript.Tests",
+    "references": [
+        "GUID:3e1c8f8caef0a0f4082a1e39e50dd5c6",
+        "GUID:27619889b8ba8c24980f49ee34dbb44a",
+        "GUID:0acc523941302664db1f4e527237feb3"
+    ],
+    "includePlatforms": [
+        "Editor"
+    ],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Tests/Editor/InteractiveScape.TouchScript.Editor.Tests.asmdef.meta
+++ b/Tests/Editor/InteractiveScape.TouchScript.Editor.Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 2d9394eb74b3e1c4c8a5abb95a2cb9ec
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Runtime.meta
+++ b/Tests/Runtime.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bddf51bbfe1db89449af5b27b0120e87
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Runtime/InteractiveScape.TouchScript.Tests.asmdef
+++ b/Tests/Runtime/InteractiveScape.TouchScript.Tests.asmdef
@@ -1,0 +1,22 @@
+{
+    "name": "InteractiveScape.TouchScript.Tests",
+    "rootNamespace": "TouchScript.Tests",
+    "references": [
+        "GUID:0d71bc8da9e4ca544a2d7ea096f2ecf0",
+        "GUID:27619889b8ba8c24980f49ee34dbb44a",
+        "GUID:0acc523941302664db1f4e527237feb3"
+    ],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": true,
+    "precompiledReferences": [
+        "nunit.framework.dll"
+    ],
+    "autoReferenced": false,
+    "defineConstraints": [
+        "UNITY_INCLUDE_TESTS"
+    ],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Tests/Runtime/InteractiveScape.TouchScript.Tests.asmdef.meta
+++ b/Tests/Runtime/InteractiveScape.TouchScript.Tests.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 728e39fccb29df849a716f99fce5f44e
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Tests/Runtime/RuntimeTestExample.cs
+++ b/Tests/Runtime/RuntimeTestExample.cs
@@ -1,0 +1,14 @@
+﻿using NUnit.Framework;
+
+namespace TouchScript.Tests
+{
+    public class RuntimeTestExample
+    {
+        [Test]
+        public void TestInt()
+        {
+            int a = 5;
+            Assert.AreEqual(5, a);
+        }
+    }
+}

--- a/Tests/Runtime/RuntimeTestExample.cs.meta
+++ b/Tests/Runtime/RuntimeTestExample.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 95a7be418e5d4125a8ea3125212da3ef
+timeCreated: 1679923156

--- a/package.json
+++ b/package.json
@@ -1,12 +1,71 @@
 {
     "name": "com.interactive-scape.touchscript",
-    "version": "0.0.1",
+    "version": "9.1.0",
     "displayName": "TouchScript",
     "description": "Multi touch library for Unity",
     "unity": "2021.3",
+    "documentationUrl": "https://github.com/InteractiveScapeGmbH/TouchScript/wiki",
     "author": {
         "name": "Interactive Scape",
         "email": "info@interative-scape.com",
         "url": "https://www.interactive-scape.com"
-    }
+    },
+    "keywords": [
+        "touch",
+        "multitouch",
+        "gestures",
+        "tuio"
+    ],
+    "samples": [
+        {
+            "displayName": "Camera",
+            "description" : "",
+            "path": "Samples~/Camera"
+        },
+        {
+            "displayName": "Checkers",
+            "description": "",
+            "path": "Samples~/Checkers"
+        },
+        {
+            "displayName": "Colors",
+            "description" : "",
+            "path": "Samples~/Colors"
+        },
+        {
+            "displayName": "Cube",
+            "description" : "",
+            "path": "Samples~/Cube"
+        },
+        {
+            "displayName": "Multiuser",
+            "description" : "",
+            "path": "Samples~/Multiuser"
+        },
+        {
+            "displayName": "Photos",
+            "description" : "",
+            "path": "Samples~/Photos"
+        },
+        {
+            "displayName": "Portal",
+            "description" : "",
+            "path": "Samples~/Portal"
+        },
+        {
+            "displayName": "Pull",
+            "description" : "",
+            "path": "Samples~/Pull"
+        },
+        {
+            "displayName": "RawInput",
+            "description" : "",
+            "path": "Samples~/RawInput"
+        },
+        {
+            "displayName": "Taps",
+            "description" : "",
+            "path": "Samples~/Taps"
+        }
+    ]
 }


### PR DESCRIPTION
The original TouchScript uses the old asset pack folder structure. 
This PR applys the new Package Manager structure. It also removes a lot of unnecessary preprocessor statements which refers to very old Unity 5.x versions.