### PR TITLE
Regarding TuioInput class: add public accessors for tuio connection t…

### DIFF
--- a/Runtime/InputSources/TuioInput.cs
+++ b/Runtime/InputSources/TuioInput.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Net;
 using TouchScript.Pointers;
 using TouchScript.Utils;
 using TuioNet.Common;
@@ -20,10 +21,49 @@ namespace TouchScript.InputSources
         private readonly ObjectPool<TouchPointer> _touchPool;
         private readonly ObjectPool<ObjectPointer> _objectPool;
 
+
+        public TuioConnectionType ConnectionType
+        {
+            get => _connectionType;
+            set
+            {
+                _connectionType = value;
+            }
+        }
+
+        public int Port
+        {
+            get => _port;
+            set
+            {
+                if(value < 0) return;
+                _port = value;
+            }
+        }
+
+        public string IpAddress
+        {
+            get => _ipAddress;
+            set
+            {
+                if(IPAddress.TryParse(value, out _))
+                {
+                    _ipAddress = value;
+                }
+            }
+        }
+
         protected TuioInput()
         {
             _touchPool = new ObjectPool<TouchPointer>(50, () => new TouchPointer(this), null, ResetPointer);
             _objectPool = new ObjectPool<ObjectPointer>(50, () => new ObjectPointer(this), null, ResetPointer);
+        }
+
+        public void Reinit()
+        {
+            Disconnect();
+            IsInitialized = false;
+            Init();
         }
 
         protected abstract void Connect();


### PR DESCRIPTION
### Issue
The _TUIO_ connection cannot be configured at runtime, because the relevant parameters (_connection type, port, ip address_) can only be set via the _Unity inspector_ fields. This makes it impossible, for example, to define the parameters via command line arguments during app start.

---

### Short term proposal (..this PR)
- Adding public accessors in the `TuioInput` class for the parameters needed to set up a TUIO client.
- Adding a `Reinit()` method to the `TuioInput` class, which allows to deliberately reestablish the connection, since the regular `Init()` method is locked after the first initialization.

---

### Long term proposal (... further suggestions)
The initialization of the _TUIO connection/client_ is automatically executed during the _Unity lifecycle_ in the `OnEnable()` method of the [InputSource class](https://github.com/InteractiveScapeGmbH/TouchScript/blob/develop/Runtime/InputSources/InputSource.cs). I suggest adding a boolean option to disable the execution of `Init()` in this `OnEnable` method and make the `Init` method public so that `Init()` can be called by any other script responsible for setting up the TUIO configuration. This also prevents connecting twice as occurs in the short-term proposal, where the _TUIO_ connection is first set up in the OnEnable method and a second time with `Reinit()` by another script.
However, this long-term proposal is not part of this pull request and is just another idea that can be discussed.