### PR TITLE
18 restore option to set tuio connection type during runtime

### DIFF
--- a/Runtime/InputSources/TuioInput.cs
+++ b/Runtime/InputSources/TuioInput.cs
@@ -45,7 +45,7 @@ namespace TouchScript.InputSources
             set
             {
                 if(value < 0) return;
-                UdpPort = value;
+                _udpPort = value;
             }
         }
 

--- a/Runtime/InputSources/TuioInput.cs
+++ b/Runtime/InputSources/TuioInput.cs
@@ -28,6 +28,15 @@ namespace TouchScript.InputSources
 
         private ITuioInput _tuioInput;
 
+        public TuioConnectionType ConnectionType
+        {
+            get => _connectionType;
+            set
+            {
+                _connectionType = value;
+            }
+        }
+
         public Vector2Int Resolution { get; private set; }
 
         public int UdpPort

--- a/Runtime/InputSources/TuioInput.cs
+++ b/Runtime/InputSources/TuioInput.cs
@@ -61,6 +61,30 @@ namespace TouchScript.InputSources
             }
         }
         
+        public int Port
+        {
+            get
+            {
+                if (_connectionType == TuioConnectionType.Websocket)
+                {
+                    return _tuioVersion switch
+                    {
+                        TuioVersion.Tuio11 => 3333,
+                        TuioVersion.Tuio20 => 3343,
+                        _ => throw new ArgumentOutOfRangeException($"{typeof(TuioVersion)} has no value of {_tuioVersion}.")
+                    };
+                }
+                else if(_connectionType == TuioConnectionType.UDP)
+                {
+                    return _udpPort;
+                }
+                else 
+                {
+                    throw new ArgumentOutOfRangeException($"{typeof(TuioConnectionType)} has no value of {_connectionType}.");
+                }
+            }
+        }
+
         public ITuioDispatcher TuioDispatcher
         {
             get
@@ -96,18 +120,7 @@ namespace TouchScript.InputSources
         protected override void Init()
         {
             if(_isInitialized) return;
-            var port = UdpPort;
-            if (_connectionType == TuioConnectionType.Websocket)
-            {
-                port = _tuioVersion switch
-                {
-                    TuioVersion.Tuio11 => 3333,
-                    TuioVersion.Tuio20 => 3343,
-                    _ => throw new ArgumentOutOfRangeException($"{typeof(TuioVersion)} has no value of {_tuioVersion}.")
-                };
-            }
-
-            _session = new TuioSession(_tuioVersion, _connectionType, IpAddress, port, false);
+            _session = new TuioSession(_tuioVersion, _connectionType, IpAddress, Port, false);
             _isInitialized = true;
         }
         

--- a/Runtime/InputSources/TuioInput.cs
+++ b/Runtime/InputSources/TuioInput.cs
@@ -5,7 +5,6 @@ using TouchScript.Pointers;
 using TouchScript.Utils;
 using TuioNet.Common;
 using UnityEngine;
-using UnityEngine.Serialization;
 
 namespace TouchScript.InputSources
 {

--- a/Runtime/InputSources/TuioInput.cs
+++ b/Runtime/InputSources/TuioInput.cs
@@ -65,23 +65,17 @@ namespace TouchScript.InputSources
         {
             get
             {
-                if (_connectionType == TuioConnectionType.Websocket)
+                return _connectionType switch
                 {
-                    return _tuioVersion switch
+                    TuioConnectionType.Websocket => _tuioVersion switch
                     {
                         TuioVersion.Tuio11 => 3333,
                         TuioVersion.Tuio20 => 3343,
                         _ => throw new ArgumentOutOfRangeException($"{typeof(TuioVersion)} has no value of {_tuioVersion}.")
-                    };
-                }
-                else if(_connectionType == TuioConnectionType.UDP)
-                {
-                    return _udpPort;
-                }
-                else 
-                {
-                    throw new ArgumentOutOfRangeException($"{typeof(TuioConnectionType)} has no value of {_connectionType}.");
-                }
+                    },
+                    TuioConnectionType.UDP => _udpPort,
+                    _ => throw new ArgumentOutOfRangeException($"{typeof(TuioConnectionType)} has no value of {_connectionType}."),
+                };
             }
         }
 


### PR DESCRIPTION
### Issue
`TuioInput` class was missing the accessor `ConnectionType`. It has been removed with Commit [367fbccc](https://github.com/InteractiveScapeGmbH/TouchScript/commit/367fbccc9e38517471538ae060d98648ecdcbe40). However, this accessor was essential for changing the connection type during runtime. This is necessary, for example, if the application switches between connection types that are defined via CLI parameters at app startup.

### Solution
Restore the removed `ConnectionType` accessor, to allow changes of the connection type during runtime (requires also to call `TuioInput.Reinit()`)

### Further changes
- solved bug in `UdpPort` accessor of TuioInput class. The set accessor wrote recursively to itself. This caused a stack overflow when setting `UdpPort`.
- added a general get accessor for the TUIO port, that returns the port for UDP connections as well as websocket connections. This accessor can be used for writing logs or user feedback messages.