### PR TITLE
write angle information of TUIO20 message to TouchPointer instances

### DIFF
--- a/Editor/InputSources/TuioInputEditor.cs
+++ b/Editor/InputSources/TuioInputEditor.cs
@@ -15,6 +15,7 @@ namespace TouchScript.Editor.InputSources
         private SerializedProperty _connectionType;
         private SerializedProperty _port;
         private SerializedProperty _ipAddress;
+        private SerializedProperty _pointerOffset;
 
         protected override void OnEnable()
         {
@@ -24,6 +25,14 @@ namespace TouchScript.Editor.InputSources
             _connectionType = serializedObject.FindProperty("_connectionType");
             _port = serializedObject.FindProperty("_port");
             _ipAddress = serializedObject.FindProperty("_ipAddress");
+            if(target is Tuio20Input)
+            {
+                _pointerOffset = serializedObject.FindProperty("_pointerOffset");
+            }
+            else
+            {
+                _pointerOffset = null;
+            }
         }
 
         public override void OnInspectorGUI()
@@ -32,6 +41,10 @@ namespace TouchScript.Editor.InputSources
             EditorGUILayout.PropertyField(_connectionType);
             EditorGUILayout.PropertyField(_port);
             EditorGUILayout.PropertyField(_ipAddress);
+            if (_pointerOffset != null)
+            {
+                EditorGUILayout.PropertyField(_pointerOffset);
+            }
             serializedObject.ApplyModifiedProperties();
             base.OnInspectorGUI();
         }

--- a/Runtime/Core/TouchManagerInstance.cs
+++ b/Runtime/Core/TouchManagerInstance.cs
@@ -236,11 +236,19 @@ namespace TouchScript.Core
         private HashSet<int> pointersRemoved = new HashSet<int>();
         private HashSet<int> pointersCancelled = new HashSet<int>();
 
-        private static ObjectPool<List<Pointer>> pointerListPool = new ObjectPool<List<Pointer>>(2,
-            () => new List<Pointer>(10), null, (l) => l.Clear());
+        private static ObjectPool<List<Pointer>> pointerListPool = new ObjectPool<List<Pointer>>(
+            capacity: 2,
+            actionNew: () => new List<Pointer>(10),
+            actionOnGet: null,
+            actionOnRelease: (l) => l.Clear()
+        );
 
-        private static ObjectPool<List<int>> intListPool = new ObjectPool<List<int>>(3, () => new List<int>(10), null,
-            (l) => l.Clear());
+        private static ObjectPool<List<int>> intListPool = new ObjectPool<List<int>>(
+            capacity: 3,
+            actionNew: () => new List<int>(10),
+            actionOnGet: null,
+            actionOnRelease: (l) => l.Clear()
+        );
 
         private int nextPointerId = 0;
         private object pointerLock = new object();

--- a/Runtime/Gestures/TapGesture.cs
+++ b/Runtime/Gestures/TapGesture.cs
@@ -113,6 +113,19 @@ namespace TouchScript.Gestures
             set { combinePointersInterval = value; }
         }
 
+        public Vector2 PointerDirection
+        {
+            get => direction.Value;
+        }
+
+        public float PointerRotation
+        {
+            get
+            {
+                return direction.ToAngle();
+            }
+        }
+
         #endregion
 
         #region Private variables
@@ -146,6 +159,7 @@ namespace TouchScript.Gestures
         private TimedSequence<Pointer> pointerSequence = new TimedSequence<Pointer>();
 
         private CustomSampler gestureSampler;
+        private SmoothedVector2 direction = new(10);
 
         #endregion
 
@@ -207,29 +221,35 @@ namespace TouchScript.Gestures
 
             if (NumPointers == pointers.Count)
             {
+                var pointer = pointers[0];
+
                 // the first ever pointer
                 if (tapsDone == 0)
                 {
-                    startPosition = pointers[0].Position;
+                    startPosition = pointer.Position;
                     if (timeLimit < float.PositiveInfinity) StartCoroutine("wait");
+                    direction.Reset();
+                    direction.Update(pointer.Rotation);
                 }
                 else if (tapsDone >= numberOfTapsRequired) // Might be delayed and retapped while waiting
                 {
                     reset();
-                    startPosition = pointers[0].Position;
+                    startPosition = pointer.Position;
                     if (timeLimit < float.PositiveInfinity) StartCoroutine("wait");
+                    direction.Update(pointer.Rotation);
                 }
                 else
                 {
                     if (distanceLimit < float.PositiveInfinity)
                     {
-                        if ((pointers[0].Position - startPosition).sqrMagnitude > distanceLimitInPixelsSquared)
+                        if ((pointer.Position - startPosition).sqrMagnitude > distanceLimitInPixelsSquared)
                         {
                             setState(GestureState.Failed);
                             gestureSampler.End();
                             return;
                         }
                     }
+                    direction.Update(pointer.Rotation);
                 }
             }
             if (pointersNumState == PointersNumState.PassedMinThreshold)

--- a/Runtime/InputSources/Tuio20Input.cs
+++ b/Runtime/InputSources/Tuio20Input.cs
@@ -91,6 +91,7 @@ namespace TouchScript.InputSources
                         y = (1f - tuioPointer.Position.Y) * ScreenHeight
                     };
                     touchPointer.Position = RemapCoordinates(screenPosition);
+                    UpdatePointerProperties(touchPointer, tuioPointer);
                     UpdatePointer(touchPointer);
                 }
 
@@ -140,6 +141,11 @@ namespace TouchScript.InputSources
         {
             pointer.ObjectId = (int)token.ComponentId;
             pointer.Angle = token.Angle;
+        }
+
+        private void UpdatePointerProperties(TouchPointer pointer, Tuio20Pointer tuioData)
+        {
+            pointer.Rotation = tuioData.Angle;
         }
     }
 }

--- a/Runtime/InputSources/Tuio20Input.cs
+++ b/Runtime/InputSources/Tuio20Input.cs
@@ -14,6 +14,9 @@ namespace TouchScript.InputSources
     {
         private TuioClient _client;
         private Tuio20Processor _processor;
+
+        [SerializeField] private float _pointerOffset = 0;
+
         protected override void Init()
         {
             if (IsInitialized) return;
@@ -58,7 +61,9 @@ namespace TouchScript.InputSources
                         x = tuioPointer.Position.X * ScreenWidth,
                         y = (1f - tuioPointer.Position.Y) * ScreenHeight
                     };
-                   TouchToInternalId.Add(tuioPointer.SessionId, AddTouch(screenPosition));
+                    var touchPointer = AddTouch(screenPosition);
+                    InitPointerProperties(touchPointer, tuioPointer);
+                    TouchToInternalId.Add(tuioPointer.SessionId, touchPointer);
                 }
 
                 if (tuio20Object.ContainsNewTuioToken())
@@ -143,9 +148,25 @@ namespace TouchScript.InputSources
             pointer.Angle = token.Angle;
         }
 
+
+        private void InitPointerProperties(TouchPointer pointer, Tuio20Pointer tuioData)
+        {
+            pointer.INTERNAL_InitRotation(ShiftAngle(tuioData.Angle, _pointerOffset));
+        }
+
         private void UpdatePointerProperties(TouchPointer pointer, Tuio20Pointer tuioData)
         {
-            pointer.Rotation = tuioData.Angle;
+            pointer.Rotation = ShiftAngle(tuioData.Angle, _pointerOffset);
+        }
+
+        private static float ShiftAngle(float angle, float offset)
+        {
+            const float TWO_PI = 2 * Mathf.PI;
+            float result = angle + offset;
+            result = result % TWO_PI;
+            if (result < 0)
+                result += TWO_PI;
+            return result;
         }
     }
 }

--- a/Runtime/Pointers/FakePointer.cs
+++ b/Runtime/Pointers/FakePointer.cs
@@ -37,6 +37,12 @@ namespace TouchScript.Pointers
         /// <inheritdoc />
         public Vector2 PreviousPosition { get; private set; }
 
+        /// <inheritdoc />
+        public float Rotation { get; set; }
+
+        /// <inheritdoc />
+        public float PreviousRotation { get; private set; }
+
         #endregion
 
         #region Constructors
@@ -48,6 +54,17 @@ namespace TouchScript.Pointers
         public FakePointer(Vector2 position) : this()
         {
             Position = position;
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="FakePointer"/> class.
+        /// </summary>
+        /// <param name="position">The position.</param>
+        /// <param name="rotation">The rotation in radians.</param>
+        public FakePointer(Vector2 position, float rotation) : this()
+        {
+            Position = PreviousPosition = position;
+            Rotation = PreviousRotation = rotation;
         }
 
         /// <summary>

--- a/Runtime/Pointers/IPointer.cs
+++ b/Runtime/Pointers/IPointer.cs
@@ -45,6 +45,16 @@ namespace TouchScript.Pointers
         Vector2 PreviousPosition { get; }
 
         /// <summary>
+        /// Rotation of the pointer in radians.
+        /// </summary>
+        float Rotation { get; set; }
+
+        /// <summary>
+        /// Previous Rotation of the pointer in radians.
+        /// </summary>
+        float PreviousRotation { get; }
+
+        /// <summary>
         /// <para>Gets or sets pointer flags: <see cref="Pointer.FLAG_ARTIFICIAL"/></para>
         /// <para>Note: setting this property doesn't immediately change its value, the value actually changes during the next TouchManager update phase.</para>
         /// </summary>

--- a/Runtime/Pointers/Pointer.cs
+++ b/Runtime/Pointers/Pointer.cs
@@ -213,6 +213,15 @@ namespace TouchScript.Pointers
         /// <inheritdoc />
         public Vector2 PreviousPosition { get; private set; }
 
+        public float Rotation
+        {
+            get { return rotation; }
+            set { newRotation = value; }
+        }
+
+        /// <inheritdoc />
+        public float PreviousRotation { get; private set; }
+
         /// <inheritdoc />
         public uint Flags { get; set; }
 
@@ -237,6 +246,7 @@ namespace TouchScript.Pointers
         private LayerManagerInstance layerManager;
         private int refCount = 0;
         private Vector2 position, newPosition;
+        private float rotation, newRotation;
         private HitData pressData, overData;
         private bool overDataIsDirty = true;
 
@@ -274,6 +284,8 @@ namespace TouchScript.Pointers
             Buttons = target.Buttons;
             position = target.position;
             newPosition = target.newPosition;
+            rotation = target.rotation;
+            newRotation = target.newRotation;
             PreviousPosition = target.PreviousPosition;
         }
 
@@ -313,6 +325,8 @@ namespace TouchScript.Pointers
             BinaryUtils.ToBinaryString(Flags, builder, 8);
             builder.Append(", position: ");
             builder.Append(Position);
+            builder.Append(", rotation: ");
+            builder.Append(Rotation);
             builder.Append(")");
             return builder.ToString();
         }
@@ -340,6 +354,7 @@ namespace TouchScript.Pointers
         {
             Id = id;
             PreviousPosition = position = newPosition;
+            PreviousRotation = rotation = newRotation;
         }
 
         internal virtual void INTERNAL_Reset()
@@ -347,6 +362,7 @@ namespace TouchScript.Pointers
             Id = INVALID_POINTER;
             INTERNAL_ClearPressData();
             position = newPosition = PreviousPosition = Vector2.zero;
+            rotation = newRotation = PreviousRotation = 0;
             Flags = 0;
             Buttons = PointerButtonState.Nothing;
             overDataIsDirty = true;
@@ -362,6 +378,13 @@ namespace TouchScript.Pointers
         {
             PreviousPosition = position;
             position = newPosition;
+            INTERNAL_UpdateRotation();
+        }
+
+        internal virtual void INTERNAL_UpdateRotation()
+        {
+            PreviousRotation = rotation;
+            rotation = newRotation;
         }
 
         internal void INTERNAL_Retain()
@@ -385,6 +408,11 @@ namespace TouchScript.Pointers
         {
             pressData = default(HitData);
             refCount = 0;
+        }
+
+        internal void INTERNAL_InitRotation(float rot)
+        {
+            PreviousRotation = rotation = newRotation = rot;
         }
 
         #endregion

--- a/Runtime/Pointers/TouchPointer.cs
+++ b/Runtime/Pointers/TouchPointer.cs
@@ -28,12 +28,6 @@ namespace TouchScript.Pointers
         #region Public properties
 
         /// <summary>
-        /// Gets or sets the touch's rotation.
-        /// </summary>
-        /// <value> Rotation in radians. </value>
-        public float Rotation { get; set; }
-
-        /// <summary>
         /// Gets or sets the touch's pressure.
         /// </summary>
         /// <value> Pressure in range [0, 1]. </value>

--- a/Runtime/Utils/SmoothedVector2.cs
+++ b/Runtime/Utils/SmoothedVector2.cs
@@ -1,0 +1,94 @@
+using UnityEngine;
+
+namespace TouchScript.Utils
+{
+    public class SmoothedVector2
+    {
+        private Vector2 _value = Vector2.zero;
+        private bool _initialized = false;
+        private readonly float _baseWeight;
+        private readonly int _maxSamples;
+        private int _count;
+
+        public Vector2 Value => _value;
+
+        /// <param name="samples">
+        /// Approximate number of samples to smooth over (e.g. 5–30)
+        /// </param>
+        public SmoothedVector2(int maxSamples)
+        {
+            _maxSamples = Mathf.Max(1, maxSamples);
+            _baseWeight = 2f / (_maxSamples + 1f);
+            _count = 0;
+        }
+
+        /// <summary>
+        /// Updates the filter with a new angle (radians)
+        /// and returns a smoothed normalized direction vector.
+        /// </summary>
+        public Vector2 Update(float angleRad)
+        {
+            Vector2 input = new Vector2(
+                Mathf.Cos(angleRad),
+                Mathf.Sin(angleRad)
+            );
+            return Update(input);
+        }
+
+        /// <summary>
+        /// Updates the filter with a new vector
+        /// and returns a smoothed normalized direction vector.
+        /// </summary>
+        public Vector2 Update(Vector2 input)
+        {
+            if (input.sqrMagnitude <= 1e-8f)
+                return _value;
+
+            input = input.normalized;
+
+            if (!_initialized)
+            {
+                _value = input;
+                _initialized = true;
+                _count = 1;
+                return _value;
+            }
+
+            // Exponential moving average
+            _count++;
+            float weight = ComputeWeight(_count);
+            _value = weight * input + (1f - weight) * _value;
+
+            // Normalize to stay on unit circle
+            if (_value.SqrMagnitude() > 1e-8f)
+                _value = _value.normalized;
+
+            return _value;
+        }
+
+        /// <summary>
+        /// returns the angle representation of the smoothed normalized direction vector.
+        /// The range is from 0 to 2 PI
+        /// </summary>
+        public float ToAngle()
+        {
+            float angle = Mathf.Atan2(_value.y, _value.x);
+            const float TWO_PI = 2 * Mathf.PI;
+            if (angle < 0f) angle += TWO_PI;
+            return angle;
+        }
+
+        public void Reset()
+        {
+            _initialized = false;
+            _count = 0;
+            _value = Vector2.zero;
+        }
+
+        float ComputeWeight(int sampleCount)
+        {
+            float scale = Mathf.Min(1f, sampleCount / (float) _maxSamples);
+            return _baseWeight * scale;
+        }
+    }
+}

--- a/Runtime/Utils/SmoothedVector2.cs.meta
+++ b/Runtime/Utils/SmoothedVector2.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 4cc14ed7b064fbc4db1afedee09cb812


### PR DESCRIPTION
### Issue
If touch pointers have an orientation, such as the orientation of the pointing finger, the angle of the transmitted TUIO 2.0 message is not applied to instances of the TouchPointer class. As a result, it is currently not possible to use TouchScript to read finger orientation.

### Solution
Write the angle from the TUIO.20 message to the instances of the TouchPointer class.

### Known Issues
This PR branch is based on [20-use-sessionid-instead-of-tuioid-as-identifier](https://github.com/InteractiveScapeGmbH/TouchScript/tree/20-use-sessionid-instead-of-tuioid-as-identifier) so that it can already be used with the features of the parent branch. Since [20-use-sessionid-instead-of-tuioid-as-identifier](https://github.com/InteractiveScapeGmbH/TouchScript/tree/20-use-sessionid-instead-of-tuioid-as-identifier) is not based on the main branch either, I have not yet updated the version number. This will probably have to be done once the two branches have been merged into the main branch.